### PR TITLE
Fix: Ensure route page appears for bike/car in trip planning

### DIFF
--- a/src/components/screens/TripPlanningFlow.tsx
+++ b/src/components/screens/TripPlanningFlow.tsx
@@ -81,10 +81,10 @@ const TripPlanningFlow = ({ onBack }: TripPlanningFlowProps) => {
     }
   };
 
-  const handleTransportNext = () => {
+  const handleTransportNext = (selectedTransport: string) => { // Added parameter
     // If car, bike, or cab is selected for "Plan Your Own Trip", show routes page
-    if (tripData.tripType === 'own' && (tripData.transport === 'car' || tripData.transport === 'bike' || tripData.transport === 'cab')) {
-      console.log('Should show routes page for transport:', tripData.transport);
+    if (tripData.tripType === 'own' && (selectedTransport === 'car' || selectedTransport === 'bike' || selectedTransport === 'cab')) { // Used parameter
+      console.log('Should show routes page for transport:', selectedTransport); // Log the parameter
       setShowRoutesPage(true);
     } else {
       handleNext();
@@ -638,7 +638,7 @@ const TransportStep = ({ tripData, setTripData, onNext }: any) => {
   const handleNext = () => {
     if (selectedTransport) {
       setTripData({ ...tripData, transport: selectedTransport });
-      onNext();
+      onNext(selectedTransport);
     }
   };
 


### PR DESCRIPTION
I refactored `handleTransportNext` in `TripPlanningFlow.tsx` to accept the selected transport mode as a parameter. This prevents an issue where the component would use a stale value of the transport mode from state when deciding whether to show the routes page.

I also updated `TransportStep` to pass the currently selected transport mode to this updated handler. This ensures that selecting 'bike', 'car', or 'cab' in the 'Plan Your Own Trip' flow correctly navigates to the `RoutesScreen`.