### PR TITLE
Style: Apply comprehensive dark mode improvements

### DIFF
--- a/src/components/screens/RoutesScreen.tsx
+++ b/src/components/screens/RoutesScreen.tsx
@@ -23,9 +23,9 @@ const RoutesScreen: React.FC<RoutesScreenProps> = ({ onNext, currentScreen, tota
       distance: '320 km',
       color: 'blue',
       icon: Zap,
-      bgColor: 'bg-blue-50',
+      bgColor: 'bg-blue-50 dark:bg-blue-800',
       borderColor: 'border-blue-500',
-      textColor: 'text-blue-600'
+      textColor: 'text-blue-600 dark:text-blue-300'
     },
     {
       id: 'scenic',
@@ -35,9 +35,9 @@ const RoutesScreen: React.FC<RoutesScreenProps> = ({ onNext, currentScreen, tota
       distance: '420 km',
       color: 'green',
       icon: Mountain,
-      bgColor: 'bg-green-50',
+      bgColor: 'bg-green-50 dark:bg-green-800',
       borderColor: 'border-green-500',
-      textColor: 'text-green-600'
+      textColor: 'text-green-600 dark:text-green-300'
     },
     {
       id: 'fuel',
@@ -47,9 +47,9 @@ const RoutesScreen: React.FC<RoutesScreenProps> = ({ onNext, currentScreen, tota
       distance: '280 km',
       color: 'red',
       icon: Fuel,
-      bgColor: 'bg-red-50',
+      bgColor: 'bg-red-50 dark:bg-red-800',
       borderColor: 'border-red-500',
-      textColor: 'text-red-600'
+      textColor: 'text-red-600 dark:text-red-300'
     }
   ];
 
@@ -62,25 +62,25 @@ const RoutesScreen: React.FC<RoutesScreenProps> = ({ onNext, currentScreen, tota
       {/* Main Content */}
       <div className="flex-1 flex flex-col items-center justify-center text-center">
         {/* Transport Icon */}
-        <div className="w-16 h-16 bg-white rounded-full shadow-lg flex items-center justify-center mb-8 animate-fade-in">
+        <div className="w-16 h-16 bg-white dark:bg-gray-700 rounded-full shadow-lg flex items-center justify-center mb-8 animate-fade-in">
           <span className="text-2xl">
             {transport === 'car' ? '🚗' : transport === 'bike' ? '🏍️' : '🚕'}
           </span>
         </div>
 
         {/* Mock Map */}
-        <div className="bg-gray-100 rounded-xl h-48 w-full max-w-sm flex items-center justify-center mb-6">
+        <div className="bg-gray-100 dark:bg-gray-700 rounded-xl h-48 w-full max-w-sm flex items-center justify-center mb-6">
           <div className="text-center">
-            <MapPin size={32} className="text-gray-400 mx-auto mb-2" />
-            <p className="text-gray-500 font-medium">Interactive Route Map</p>
-            <p className="text-sm text-gray-400">Current location → {destination}</p>
+            <MapPin size={32} className="text-gray-400 dark:text-gray-500 mx-auto mb-2" />
+            <p className="text-gray-500 dark:text-gray-400 font-medium">Interactive Route Map</p>
+            <p className="text-sm text-gray-400 dark:text-gray-500">Current location → {destination}</p>
           </div>
         </div>
 
-        <h2 className="text-2xl font-bold text-blue-600 mb-3">
+        <h2 className="text-2xl font-bold text-blue-600 dark:text-blue-400 mb-3">
           Choose Your Route to {destination}
         </h2>
-        <p className="text-gray-600 mb-6 max-w-xs">
+        <p className="text-gray-600 dark:text-gray-300 mb-6 max-w-xs">
           Select the best route for your {transport} journey
         </p>
 
@@ -95,19 +95,19 @@ const RoutesScreen: React.FC<RoutesScreenProps> = ({ onNext, currentScreen, tota
                 className={`flex items-center p-4 rounded-2xl border-2 transition-all duration-200 w-full ${
                   selectedRoute === route.id 
                     ? `${route.bgColor} ${route.borderColor} shadow-lg scale-105` 
-                    : 'bg-white border-gray-200 hover:bg-gray-50'
+                    : 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700'
                 }`}
               >
-                <div className={`p-2 rounded-lg mr-4 ${selectedRoute === route.id ? route.bgColor : 'bg-gray-100'}`}>
-                  <Icon size={20} className={selectedRoute === route.id ? route.textColor : 'text-gray-600'} />
+                <div className={`p-2 rounded-lg mr-4 ${selectedRoute === route.id ? route.bgColor : 'bg-gray-100 dark:bg-gray-700'}`}>
+                  <Icon size={20} className={selectedRoute === route.id ? route.textColor : 'text-gray-600 dark:text-gray-300'} />
                 </div>
                 <div className="flex-1 text-left">
                   <div className="flex items-center justify-between mb-1">
-                    <h3 className="font-semibold text-gray-800">{route.name}</h3>
-                    <span className="text-sm font-medium text-gray-600">{route.duration}</span>
+                    <h3 className="font-semibold text-gray-800 dark:text-gray-100">{route.name}</h3>
+                    <span className="text-sm font-medium text-gray-600 dark:text-gray-300">{route.duration}</span>
                   </div>
-                  <p className="text-sm text-gray-600 mb-1">{route.description}</p>
-                  <p className="text-xs text-gray-500">{route.distance}</p>
+                  <p className="text-sm text-gray-600 dark:text-gray-300 mb-1">{route.description}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{route.distance}</p>
                 </div>
               </button>
             );
@@ -130,7 +130,7 @@ const RoutesScreen: React.FC<RoutesScreenProps> = ({ onNext, currentScreen, tota
             <div
               key={index}
               className={`w-2 h-2 rounded-full transition-all duration-300 ${
-                index === currentScreen ? 'bg-blue-500 w-6' : 'bg-gray-300'
+                index === currentScreen ? 'bg-blue-500 w-6' : 'bg-gray-300 dark:bg-gray-600'
               }`}
             />
           ))}

--- a/src/components/screens/TripPlanningFlow.tsx
+++ b/src/components/screens/TripPlanningFlow.tsx
@@ -403,11 +403,12 @@ const DestinationStep = ({ tripData, setTripData, onNext }: any) => {
             onClick={() => setSelectedDestination(destination.id || destination.name)}
             className={`w-full p-4 rounded-xl border-2 transition-all text-left ${
               selectedDestination === (destination.id || destination.name)
-                ? 'border-blue-500 bg-blue-50'
-                : 'border-gray-200 bg-white hover:border-gray-300'
+                ? 'border-blue-500 bg-blue-50 dark:bg-blue-800 dark:border-blue-500'
+                : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-700'
             }`}
           >
             {tripData.tripType === 'package' ? (
+              // Package Trip Display - Already Modified
               <div className="space-y-4">
                 <img
                   src={destination.image}
@@ -417,9 +418,9 @@ const DestinationStep = ({ tripData, setTripData, onNext }: any) => {
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-2">
-                      <h3 className="text-xl font-bold text-gray-800">{destination.name}</h3>
+                      <h3 className="text-xl font-bold text-gray-800 dark:text-gray-100">{destination.name}</h3>
                       {destination.isAIRecommended && (
-                        <div className="flex items-center space-x-1 bg-purple-100 text-purple-700 px-2 py-1 rounded-full text-xs">
+                        <div className="flex items-center space-x-1 bg-purple-100 dark:bg-purple-800 text-purple-700 dark:text-purple-300 px-2 py-1 rounded-full text-xs">
                           <Sparkles size={12} />
                           <span>AI Pick</span>
                         </div>
@@ -427,41 +428,41 @@ const DestinationStep = ({ tripData, setTripData, onNext }: any) => {
                     </div>
                     <div className="text-right">
                       <div className="flex items-center space-x-2">
-                        <span className="text-lg font-bold text-gray-800">{destination.price}</span>
-                        <span className="text-sm text-gray-500 line-through">{destination.originalPrice}</span>
+                        <span className="text-lg font-bold text-gray-800 dark:text-gray-100">{destination.price}</span>
+                        <span className="text-sm text-gray-500 dark:text-gray-400 line-through">{destination.originalPrice}</span>
                       </div>
                       <div className="flex items-center space-x-1">
                         <Star size={14} className="text-yellow-500 fill-current" />
-                        <span className="text-sm text-gray-600">{destination.rating} ({destination.reviews} reviews)</span>
+                        <span className="text-sm text-gray-600 dark:text-gray-300">{destination.rating} ({destination.reviews} reviews)</span>
                       </div>
                     </div>
                   </div>
                   
-                  <p className="text-gray-600">{destination.description}</p>
+                  <p className="text-gray-600 dark:text-gray-300">{destination.description}</p>
                   
                   <div className="grid grid-cols-2 gap-4 text-sm">
                     <div>
-                      <span className="font-semibold text-gray-700">Duration:</span>
-                      <p className="text-gray-600">{destination.duration}</p>
+                      <span className="font-semibold text-gray-700 dark:text-gray-200">Duration:</span>
+                      <p className="text-gray-600 dark:text-gray-300">{destination.duration}</p>
                     </div>
                     <div>
-                      <span className="font-semibold text-gray-700">Transport:</span>
-                      <p className="text-gray-600">{destination.transport}</p>
+                      <span className="font-semibold text-gray-700 dark:text-gray-200">Transport:</span>
+                      <p className="text-gray-600 dark:text-gray-300">{destination.transport}</p>
                     </div>
                   </div>
 
                   <div className="space-y-2">
                     <div className="flex items-center space-x-2">
                       <Hotel size={16} className="text-blue-600" />
-                      <span className="font-semibold text-gray-700">{destination.hotel.name}</span>
+                      <span className="font-semibold text-gray-700 dark:text-gray-200">{destination.hotel.name}</span>
                       <div className="flex items-center space-x-1">
                         <Star size={12} className="text-yellow-500 fill-current" />
-                        <span className="text-xs text-gray-600">{destination.hotel.rating}</span>
+                        <span className="text-xs text-gray-600 dark:text-gray-300">{destination.hotel.rating}</span>
                       </div>
                     </div>
                     <div className="flex flex-wrap gap-1">
                       {destination.hotel.amenities.map((amenity, index) => (
-                        <span key={index} className="bg-gray-100 text-gray-700 px-2 py-1 rounded-full text-xs">
+                        <span key={index} className="bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 px-2 py-1 rounded-full text-xs">
                           {amenity}
                         </span>
                       ))}
@@ -469,10 +470,10 @@ const DestinationStep = ({ tripData, setTripData, onNext }: any) => {
                   </div>
 
                   <div className="space-y-2">
-                    <span className="font-semibold text-gray-700">Spots to Visit:</span>
+                    <span className="font-semibold text-gray-700 dark:text-gray-200">Spots to Visit:</span>
                     <div className="flex flex-wrap gap-1">
                       {destination.spots.map((spot, index) => (
-                        <span key={index} className="bg-blue-100 text-blue-700 px-2 py-1 rounded-full text-xs">
+                        <span key={index} className="bg-blue-100 dark:bg-blue-800 text-blue-700 dark:text-blue-300 px-2 py-1 rounded-full text-xs">
                           {spot}
                         </span>
                       ))}
@@ -480,8 +481,8 @@ const DestinationStep = ({ tripData, setTripData, onNext }: any) => {
                   </div>
 
                   <div className="space-y-2">
-                    <span className="font-semibold text-gray-700">Package Highlights:</span>
-                    <ul className="text-sm text-gray-600 space-y-1">
+                    <span className="font-semibold text-gray-700 dark:text-gray-200">Package Highlights:</span>
+                    <ul className="text-sm text-gray-600 dark:text-gray-300 space-y-1">
                       {destination.highlights.map((highlight, index) => (
                         <li key={index} className="flex items-center space-x-2">
                           <span className="text-green-500">✓</span>
@@ -501,15 +502,15 @@ const DestinationStep = ({ tripData, setTripData, onNext }: any) => {
                 />
                 <div className="flex-1 space-y-2">
                   <div className="flex items-center justify-between">
-                    <h3 className="font-semibold text-gray-800">{destination.name}</h3>
+                    <h3 className="font-semibold text-gray-800 dark:text-gray-100">{destination.name}</h3>
                     {destination.isAIRecommended && (
-                      <div className="flex items-center space-x-1 bg-purple-100 text-purple-700 px-2 py-1 rounded-full text-xs">
+                      <div className="flex items-center space-x-1 bg-purple-100 dark:bg-purple-800 text-purple-700 dark:text-purple-300 px-2 py-1 rounded-full text-xs">
                         <Sparkles size={12} />
                         <span>AI Pick</span>
                       </div>
                     )}
                   </div>
-                  <p className="text-sm text-gray-600 line-clamp-2">{destination.description}</p>
+                  <p className="text-sm text-gray-600 dark:text-gray-300 line-clamp-2">{destination.description}</p>
                 </div>
               </div>
             )}


### PR DESCRIPTION
This commit addresses your feedback regarding UI appearance in dark mode on several screens.

Modifications in `src/components/screens/RoutesScreen.tsx`:
- Adjusted background and text colors for route selection options (time, scenic, fuel) to be dark-mode friendly, resolving issues with overly bright or 'ugly' appearances when selected.
- Ensured all text and icons on this screen have proper contrast in dark mode.
- Updated other elements like map placeholders and titles for dark mode consistency.

Modifications in `src/components/screens/TripPlanningFlow.tsx` (within `DestinationStep`):
- Corrected 'some grey' text in package descriptions and details by applying appropriate light text colors for dark mode.
- Updated card backgrounds for both package and regular destinations to use dark mode-appropriate shades.
- Styled badges (AI Pick, amenities, spots) for better visual integration in dark mode.